### PR TITLE
Buffers

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,8 +1,9 @@
 julia 0.6 0.7-
 Reexport
-StatsBase
+StatsBase 0.22
 StatsFuns
 Optim 0.15.0
 ForwardDiff
 Distributions
 Roots
+Compat

--- a/src/ARCH.jl
+++ b/src/ARCH.jl
@@ -24,8 +24,9 @@ using Distributions
 using Roots
 using Compat #for circular_buffer
 import StatsBase: stderror
+import DataStructures: CircularBuffer, _buffer_index_checked, _buffer_index,
+                       capacity, isfull
 include("circular_buffer.jl")# no bounds checks
-#using DataStructures: CircularBuffer
 import Base: show, showerror, Random.rand, eltype, mean
 import StatsBase: StatisticalModel, loglikelihood, nobs, fit, fit!, adjr2, aic,
                   bic, aicc, dof, coef, coefnames, coeftable, CoefTable

--- a/src/EGARCH.jl
+++ b/src/EGARCH.jl
@@ -26,6 +26,25 @@ EGARCH{o, p, q}(coefs::Vector{T}) where {o, p, q, T}  = EGARCH{o, p, q, T}(coefs
         lht[t] += garchcoefs[i+1+o+p]*(abs(zt[t-i]) - sqrt2invpi)
     end
     ht[t] = exp(lht[t])
+    zt[t] = (data[t]-mean(MS, meancoefs))/sqrt(ht[t])
+    return nothing
+end
+
+@inline function bufupdate!(ht, lht, zt, ::Type{<:EGARCH{o, p ,q}}, MS::Type{<:MeanSpec},
+                         data, garchcoefs, meancoefs, t
+                         ) where {o, p, q}
+    mlht = garchcoefs[1]
+    for i = 1:o
+        mlht += garchcoefs[i+1]*zt[end-i+1]
+    end
+    for i = 1:p
+        mlht += garchcoefs[i+1+o]*lht[end-i+1]
+    end
+    for i = 1:q
+        mlht += garchcoefs[i+1+o+p]*(abs(zt[end-i+1]) - sqrt2invpi)
+    end
+    push!(lht, mlht)
+    push!(ht, exp(mlht))
     return nothing
 end
 

--- a/src/EGARCH.jl
+++ b/src/EGARCH.jl
@@ -15,24 +15,6 @@ EGARCH{o, p, q}(coefs::Vector{T}) where {o, p, q, T}  = EGARCH{o, p, q, T}(coefs
 @inline function update!(ht, lht, zt, ::Type{<:EGARCH{o, p ,q}}, MS::Type{<:MeanSpec},
                          data, garchcoefs, meancoefs, t
                          ) where {o, p, q}
-    lht[t] = garchcoefs[1]
-    for i = 1:o
-        lht[t] += garchcoefs[i+1]*zt[t-i]
-    end
-    for i = 1:p
-        lht[t] += garchcoefs[i+1+o]*lht[t-i]
-    end
-    for i = 1:q
-        lht[t] += garchcoefs[i+1+o+p]*(abs(zt[t-i]) - sqrt2invpi)
-    end
-    ht[t] = exp(lht[t])
-    zt[t] = (data[t]-mean(MS, meancoefs))/sqrt(ht[t])
-    return nothing
-end
-
-@inline function bufupdate!(ht, lht, zt, ::Type{<:EGARCH{o, p ,q}}, MS::Type{<:MeanSpec},
-                         data, garchcoefs, meancoefs, t
-                         ) where {o, p, q}
     mlht = garchcoefs[1]
     for i = 1:o
         mlht += garchcoefs[i+1]*zt[end-i+1]

--- a/src/GARCH.jl
+++ b/src/GARCH.jl
@@ -19,20 +19,6 @@ const _ARCH = GARCH{0}
 @inline function update!(ht, lht, zt, ::Type{<:GARCH{p,q}}, MS::Type{<:MeanSpec},
                          data, garchcoefs, meancoefs, t
                          ) where {p, q}
-    ht[t] = garchcoefs[1]
-    for i = 1:p
-        ht[t] += garchcoefs[i+1]*ht[t-i]
-    end
-    for i = 1:q
-        ht[t] += garchcoefs[i+1+p]*(data[t-i]-mean(MS, meancoefs))^2
-    end
-    lht[t] = log(ht[t])
-    return nothing
-end
-
-@inline function bufupdate!(ht, lht, zt, ::Type{<:GARCH{p,q}}, MS::Type{<:MeanSpec},
-                         data, garchcoefs, meancoefs, t
-                         ) where {p, q}
     mht = garchcoefs[1]
     for i = 1:p
         mht += garchcoefs[i+1]*ht[end-i+1]

--- a/src/GARCH.jl
+++ b/src/GARCH.jl
@@ -30,6 +30,21 @@ const _ARCH = GARCH{0}
     return nothing
 end
 
+@inline function bufupdate!(ht, lht, zt, ::Type{<:GARCH{p,q}}, MS::Type{<:MeanSpec},
+                         data, garchcoefs, meancoefs, t
+                         ) where {p, q}
+    mht = garchcoefs[1]
+    for i = 1:p
+        mht += garchcoefs[i+1]*ht[end-i+1]
+    end
+    for i = 1:q
+        mht += garchcoefs[i+1+p]*(data[t-i]-mean(MS, meancoefs))^2
+    end
+    push!(ht, mht)
+    push!(lht, mht>0? log(mht) : -mht)
+    return nothing
+end
+
 @inline function uncond(::Type{<:GARCH{p, q}}, coefs::Vector{T}) where {p, q, T}
     den=one(T)
     for i = 1:p+q

--- a/src/circular_buffer.jl
+++ b/src/circular_buffer.jl
@@ -1,0 +1,45 @@
+"""
+New items are pushed to the back of the list, overwriting values in a circular fashion.
+"""
+mutable struct CircularBuffer{T} <: AbstractVector{T}
+    capacity::Int
+    first::Int
+    buffer::Vector{T}
+    CircularBuffer{T}(capacity::Int) where {T} = new{T}(capacity, 1, zeros(T, capacity))
+end
+
+
+
+@inline function _buffer_index_checked(cb::CircularBuffer, i::Int)
+    n = cb.capacity
+    idx = cb.first + i - 1
+    if idx > n
+        idx - n
+    else
+        idx
+    end
+end
+
+@inline function Base.getindex(cb::CircularBuffer, i::Int)
+    cb.buffer[_buffer_index_checked(cb, i)]
+end
+
+@inline function Base.setindex!(cb::CircularBuffer, data, i::Int)
+    cb.buffer[_buffer_index_checked(cb, i)] = data
+    cb
+end
+
+
+@inline function Base.push!(cb::CircularBuffer, data)
+    cb.first = (cb.first == cb.capacity ? 1 : cb.first + 1)
+    cb.buffer[_buffer_index_checked(cb, cb.capacity)] = data
+    cb
+end
+
+@inline Base.length(cb::CircularBuffer) = cb.capacity
+@inline Base.size(cb::CircularBuffer) = (length(cb),)
+@inline Base.convert(::Type{Array}, cb::CircularBuffer{T}) where {T} = T[x for x in cb]
+@inline Base.isempty(cb::CircularBuffer) = false
+
+@inline capacity(cb::CircularBuffer) = cb.capacity
+@inline isfull(cb::CircularBuffer) = length(cb) == cb.capacity

--- a/src/circular_buffer.jl
+++ b/src/circular_buffer.jl
@@ -4,13 +4,25 @@ New items are pushed to the back of the list, overwriting values in a circular f
 mutable struct CircularBuffer{T} <: AbstractVector{T}
     capacity::Int
     first::Int
+    length::Int
     buffer::Vector{T}
-    CircularBuffer{T}(capacity::Int) where {T} = new{T}(capacity, 1, zeros(T, capacity))
+
+    CircularBuffer{T}(capacity::Int) where {T} = new{T}(capacity, 1, 0, Vector{T}(undef, capacity))
 end
 
+function Base.empty!(cb::CircularBuffer)
+    cb.length = 0
+    cb
+end
 
+Base.@propagate_inbounds function _buffer_index_checked(cb::CircularBuffer, i::Int)
+    @boundscheck if i < 1 || i > cb.length
+        throw(BoundsError(cb, i))
+    end
+    _buffer_index(cb, i)
+end
 
-@inline function _buffer_index_checked(cb::CircularBuffer, i::Int)
+@inline function _buffer_index(cb::CircularBuffer, i::Int)
     n = cb.capacity
     idx = cb.first + i - 1
     if idx > n
@@ -20,26 +32,68 @@ end
     end
 end
 
-@inline function Base.getindex(cb::CircularBuffer, i::Int)
+@inline Base.@propagate_inbounds function Base.getindex(cb::CircularBuffer, i::Int)
     cb.buffer[_buffer_index_checked(cb, i)]
 end
 
-@inline function Base.setindex!(cb::CircularBuffer, data, i::Int)
+@inline Base.@propagate_inbounds function Base.setindex!(cb::CircularBuffer, data, i::Int)
     cb.buffer[_buffer_index_checked(cb, i)] = data
     cb
 end
 
+function Base.pop!(cb::CircularBuffer)
+    if cb.length == 0
+        throw(ArgumentError("array must be non-empty"))
+    end
+    i = _buffer_index(cb, cb.length)
+    cb.length -= 1
+    cb.buffer[i]
+end
 
 @inline function Base.push!(cb::CircularBuffer, data)
-    cb.first = (cb.first == cb.capacity ? 1 : cb.first + 1)
-    cb.buffer[_buffer_index_checked(cb, cb.capacity)] = data
+    # if full, increment and overwrite, otherwise push
+    if cb.length == cb.capacity
+        cb.first = (cb.first == cb.capacity ? 1 : cb.first + 1)
+    else
+        cb.length += 1
+    end
+    cb.buffer[_buffer_index(cb, cb.length)] = data
     cb
 end
 
-@inline Base.length(cb::CircularBuffer) = cb.capacity
-@inline Base.size(cb::CircularBuffer) = (length(cb),)
-@inline Base.convert(::Type{Array}, cb::CircularBuffer{T}) where {T} = T[x for x in cb]
-@inline Base.isempty(cb::CircularBuffer) = false
+function Compat.popfirst!(cb::CircularBuffer)
+    if cb.length == 0
+        throw(ArgumentError("array must be non-empty"))
+    end
+    i = cb.first
+    cb.first = (cb.first + 1 > cb.capacity ? 1 : cb.first + 1)
+    cb.length -= 1
+    cb.buffer[i]
+end
 
-@inline capacity(cb::CircularBuffer) = cb.capacity
-@inline isfull(cb::CircularBuffer) = length(cb) == cb.capacity
+function Compat.pushfirst!(cb::CircularBuffer, data)
+    # if full, decrement and overwrite, otherwise pushfirst
+    if cb.length < cb.capacity
+        cb.length += 1
+    end
+    cb.first = (cb.first == 1 ? cb.length : cb.first - 1)
+    cb.buffer[cb.first] = data
+    cb
+end
+
+function Base.append!(cb::CircularBuffer, datavec::AbstractVector)
+    # push at most last `capacity` items
+    n = length(datavec)
+    for i in max(1, n-capacity(cb)+1):n
+        push!(cb, datavec[i])
+    end
+    cb
+end
+
+Base.length(cb::CircularBuffer) = cb.length
+Base.size(cb::CircularBuffer) = (length(cb),)
+Base.convert(::Type{Array}, cb::CircularBuffer{T}) where {T} = T[x for x in cb]
+Base.isempty(cb::CircularBuffer) = cb.length == 0
+
+capacity(cb::CircularBuffer) = cb.capacity
+isfull(cb::CircularBuffer) = length(cb) == cb.capacity

--- a/src/circular_buffer.jl
+++ b/src/circular_buffer.jl
@@ -1,20 +1,3 @@
-"""
-New items are pushed to the back of the list, overwriting values in a circular fashion.
-"""
-mutable struct CircularBuffer{T} <: AbstractVector{T}
-    capacity::Int
-    first::Int
-    length::Int
-    buffer::Vector{T}
-
-    CircularBuffer{T}(capacity::Int) where {T} = new{T}(capacity, 1, 0, Vector{T}(undef, capacity))
-end
-
-function Base.empty!(cb::CircularBuffer)
-    cb.length = 0
-    cb
-end
-
 Base.@propagate_inbounds function _buffer_index_checked(cb::CircularBuffer, i::Int)
     @boundscheck if i < 1 || i > cb.length
         throw(BoundsError(cb, i))
@@ -41,15 +24,6 @@ end
     cb
 end
 
-function Base.pop!(cb::CircularBuffer)
-    if cb.length == 0
-        throw(ArgumentError("array must be non-empty"))
-    end
-    i = _buffer_index(cb, cb.length)
-    cb.length -= 1
-    cb.buffer[i]
-end
-
 @inline function Base.push!(cb::CircularBuffer, data)
     # if full, increment and overwrite, otherwise push
     if cb.length == cb.capacity
@@ -60,40 +34,3 @@ end
     cb.buffer[_buffer_index(cb, cb.length)] = data
     cb
 end
-
-function Compat.popfirst!(cb::CircularBuffer)
-    if cb.length == 0
-        throw(ArgumentError("array must be non-empty"))
-    end
-    i = cb.first
-    cb.first = (cb.first + 1 > cb.capacity ? 1 : cb.first + 1)
-    cb.length -= 1
-    cb.buffer[i]
-end
-
-function Compat.pushfirst!(cb::CircularBuffer, data)
-    # if full, decrement and overwrite, otherwise pushfirst
-    if cb.length < cb.capacity
-        cb.length += 1
-    end
-    cb.first = (cb.first == 1 ? cb.length : cb.first - 1)
-    cb.buffer[cb.first] = data
-    cb
-end
-
-function Base.append!(cb::CircularBuffer, datavec::AbstractVector)
-    # push at most last `capacity` items
-    n = length(datavec)
-    for i in max(1, n-capacity(cb)+1):n
-        push!(cb, datavec[i])
-    end
-    cb
-end
-
-Base.length(cb::CircularBuffer) = cb.length
-Base.size(cb::CircularBuffer) = (length(cb),)
-Base.convert(::Type{Array}, cb::CircularBuffer{T}) where {T} = T[x for x in cb]
-Base.isempty(cb::CircularBuffer) = cb.length == 0
-
-capacity(cb::CircularBuffer) = cb.capacity
-isfull(cb::CircularBuffer) = length(cb) == cb.capacity

--- a/src/standardizeddistributions.jl
+++ b/src/standardizeddistributions.jl
@@ -46,9 +46,9 @@ function startingvals(::Type{<:StdTDist}, data::Array{T}) where {T}
     eabst(ν)=2*sqrt(ν-2)/(ν-1)/beta(ν/2, 1/2)
     ##alteratively, could use mean of log(abs(t)):
     #elogabst(ν)=log(ν-2)/2-digamma(ν/2)/2+digamma(1/2)/2
-    ht = zeros(data)
-    lht = zeros(data)
-    zt = zeros(data)
+    ht = T[]
+    lht = T[]
+    zt = T[]
     loglik!(ht, lht, zt, GARCH{1, 1}, StdNormal, Intercept, data, vcat(startingvals(GARCH{1, 1}, data), startingvals(Intercept, data)))
     lower = convert(T, 2)
     upper = convert(T, 30)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using Base.Test
 using ARCH
 #=
 Data from [1]. See [2] for a comparsion of GARCH software based on this data.
-[1] Bollerslev, T. and Ghysels, E. (1996), Periodic Autoregressive Conditional Heteroscedasticity, Journal of Business and Economic Statistics (14), pp. 139-151. https://doi.org/10.2307/1392425 
+[1] Bollerslev, T. and Ghysels, E. (1996), Periodic Autoregressive Conditional Heteroscedasticity, Journal of Business and Economic Statistics (14), pp. 139-151. https://doi.org/10.2307/1392425
 [2] Brooks, C., Burke, S. P., and Persand, G. (2001), Benchmarks and the accuracy of GARCH model estimation, International Journal of Forecasting (17), pp. 45-56. https://doi.org/10.1016/S0169-2070(00)00070-4
 =#
 #using HTTP
@@ -18,9 +18,9 @@ srand(1);
 datat = simulate(spec, T; dist=StdTDist(4))
 srand(1);
 datam = simulate(spec, T; dist=StdTDist(4), meanspec=Intercept(3))
-ht = zeros(data);
-lht = zeros(data);
-zt = zeros(data);
+ht = Float64[]
+lht = Float64[]
+zt = Float64[]
 am = selectmodel(GARCH, data; meanspec=NoIntercept)
 am2 = ARCHModel(spec, data)
 fit!(am2)
@@ -89,9 +89,6 @@ e = @test_throws ARCH.NumParamError ARCH.loglik!(ht, lht, zt, typeof(spec), StdN
 str = sprint(showerror, e.value)
 @test startswith(str, "incorrect number of parameters")
 @test_throws ARCH.NumParamError GARCH{1, 1}([.1])
-e = @test_throws ARCH.LengthMismatchError ARCHModel(spec, data, ht[1:10])
-str = sprint(showerror, e.value)
-@test startswith(str, "length of arrays does not match")
 io = IOBuffer()
 str = sprint(io -> show(io, am))
 @test startswith(str, "\nGARCH{1,1")


### PR DESCRIPTION
This uses CircularBuffer from DataStructures to store the ht/lht/zt inside the likelihood. This makes it possible to use autodiff in optimize, leading to a ~6x speedup for EGARCH, and ~2x for GARCH.